### PR TITLE
Fix for Ventura 13.3 Metal graphic

### DIFF
--- a/Polaris22Fixup.xcodeproj/project.pbxproj
+++ b/Polaris22Fixup.xcodeproj/project.pbxproj
@@ -412,7 +412,7 @@
 				MODULE_NAME = com.osy86.Polaris22Fixup;
 				MODULE_START = "$(PRODUCT_NAME)_kern_start";
 				MODULE_STOP = "$(PRODUCT_NAME)_kern_stop";
-				MODULE_VERSION = 1.3.6;
+				MODULE_VERSION = 1.3.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.osy86.Polaris22Fixup;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = kext;
@@ -440,7 +440,7 @@
 				MODULE_NAME = com.osy86.Polaris22Fixup;
 				MODULE_START = "$(PRODUCT_NAME)_kern_start";
 				MODULE_STOP = "$(PRODUCT_NAME)_kern_stop";
-				MODULE_VERSION = 1.3.6;
+				MODULE_VERSION = 1.3.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.osy86.Polaris22Fixup;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = kext;

--- a/Polaris22Fixup/kern_start.cpp
+++ b/Polaris22Fixup/kern_start.cpp
@@ -51,6 +51,15 @@ static const uint8_t kMontereyAmdBronzeMtlAddrLibGetBaseArrayModeReturnPatched[]
     0x0f, 0x95, 0xc0, 0x31, 0xc0, 0x83, 0xc0, 0x02, 0x5d, 0xc3, 0x55,
 };
 
+static const uint8_t kVentura133AmdBronzeMtlAddrLibGetBaseArrayModeReturnOriginal[] = {
+    0x83, 0xc0, 0x02, 0xeb, 0x0e, 0x31, 0xc0, 0xf6, 0x47, 0x08, 0xc0, 0x0f, 0x95, 0xc0, 0x01, 0xc0, 0x83, 0xc0, 0x02, 0x5d, 0xc3, 0x55,
+};
+
+static const uint8_t kVentura133AmdBronzeMtlAddrLibGetBaseArrayModeReturnPatched[] = {
+    0x83, 0xc0, 0x02, 0xeb, 0x09, 0x31, 0xc0, 0xf6, 0x47, 0x08, 0xc0, 0x0f, 0x95, 0xc0, 0x31, 0xc0, 0x83, 0xc0, 0x02, 0x5d, 0xc3, 0x55,
+};
+
+
 static constexpr size_t kMontereyAmdBronzeMtlAddrLibGetBaseArrayModeReturnSize = sizeof(kMontereyAmdBronzeMtlAddrLibGetBaseArrayModeReturnOriginal);
 
 static_assert(kMontereyAmdBronzeMtlAddrLibGetBaseArrayModeReturnSize == sizeof(kMontereyAmdBronzeMtlAddrLibGetBaseArrayModeReturnPatched), "patch size invalid");
@@ -183,11 +192,19 @@ static void patched_cs_validate_page(vnode_t vp,
             DBGLOG(MODULE_SHORT, "found function to patch at %s!", path);
             return;
         }
-        // covers pattern in macOS 12.3+
+        // covers pattern in macOS 13.3+
+        // patch for 12.3-13.3 is a substring of this patch. So run this first.
+        // TODO: use getKernelVersion and KernelMinorVersion in Lilu for more clear implementation
+        if (UNLIKELY(KernelPatcher::findAndReplace(const_cast<void *>(data), PAGE_SIZE, kVentura133AmdBronzeMtlAddrLibGetBaseArrayModeReturnOriginal, sizeof(kVentura133AmdBronzeMtlAddrLibGetBaseArrayModeReturnOriginal), kVentura133AmdBronzeMtlAddrLibGetBaseArrayModeReturnPatched, sizeof(kVentura133AmdBronzeMtlAddrLibGetBaseArrayModeReturnPatched)))) {
+            DBGLOG(MODULE_SHORT, "found function to patch at %s!", path);
+            return;
+        }
+        // covers pattern in macOS 12.3 - 13.2
         if (UNLIKELY(KernelPatcher::findAndReplace(const_cast<void *>(data), PAGE_SIZE, kMontereyAmdBronzeMtlAddrLibGetBaseArrayModeReturnOriginal, sizeof(kMontereyAmdBronzeMtlAddrLibGetBaseArrayModeReturnOriginal), kMontereyAmdBronzeMtlAddrLibGetBaseArrayModeReturnPatched, sizeof(kMontereyAmdBronzeMtlAddrLibGetBaseArrayModeReturnPatched)))) {
             DBGLOG(MODULE_SHORT, "found function to patch at %s!", path);
             return;
         }
+
     }
 }
 


### PR DESCRIPTION
What is tested to work:
- [x] 13.4 beta support.
- [x] 13.3.1 support 

If you can't wait for this PR merge, you can grab the unofficial kext here
https://github.com/goodbest/Polaris22Fixup/releases/tag/v1.3.7