### PR TITLE
Support for macOS Sequoia.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# macOS Finder
+.DS_Store
+.Trashes
+
+# Xcode related
+project.xcworkspace/
+xcuserdata/
+
+# Lulu dependency
+Lulu.kext
+Lulu.kext/**

--- a/HowToBuild.md
+++ b/HowToBuild.md
@@ -1,0 +1,8 @@
+# How to build
+
+1. Download git submodules:
+  ```git submodule update --init```
+
+1. Download a [DEBUG version of the Lulu kext](https://github.com/acidanthera/lilu/releases), and place in the repository root folder under the name `Lulu.kext`.  You do **not** need the Apple Kernel Debug Kit (KDK) to build this kext.
+
+1. Open the Xcode project, select the x86 build, and build for release.

--- a/Polaris22Fixup.xcodeproj/project.pbxproj
+++ b/Polaris22Fixup.xcodeproj/project.pbxproj
@@ -412,7 +412,7 @@
 				MODULE_NAME = com.osy86.Polaris22Fixup;
 				MODULE_START = "$(PRODUCT_NAME)_kern_start";
 				MODULE_STOP = "$(PRODUCT_NAME)_kern_stop";
-				MODULE_VERSION = 1.3.7;
+				MODULE_VERSION = 1.3.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.osy86.Polaris22Fixup;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = kext;
@@ -440,7 +440,7 @@
 				MODULE_NAME = com.osy86.Polaris22Fixup;
 				MODULE_START = "$(PRODUCT_NAME)_kern_start";
 				MODULE_STOP = "$(PRODUCT_NAME)_kern_stop";
-				MODULE_VERSION = 1.3.7;
+				MODULE_VERSION = 1.3.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.osy86.Polaris22Fixup;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = kext;

--- a/Polaris22Fixup/kern_start.cpp
+++ b/Polaris22Fixup/kern_start.cpp
@@ -59,6 +59,27 @@ static const uint8_t kVentura133AmdBronzeMtlAddrLibGetBaseArrayModeReturnPatched
     0x83, 0xc0, 0x02, 0xeb, 0x09, 0x31, 0xc0, 0xf6, 0x47, 0x08, 0xc0, 0x0f, 0x95, 0xc0, 0x31, 0xc0, 0x83, 0xc0, 0x02, 0x5d, 0xc3, 0x55,
 };
 
+/* macOS Sequoia 15+
+ *
+ * 0:  0f 95 c0                setne  al
+ * 3:  8d 04 45 02 00 00 00    lea    eax,[rax*2+0x2] ; patch this out to return ADDR_TM_1D_TILED_THIN1
+ * a:  5d                      pop    rbp
+ * b:  c3                      ret
+ */
+static const uint8_t kSequoiaAmdBronzeMtlAddrLibGetBaseArrayModeReturnOriginal[] = {
+    0x0f, 0x95, 0xc0, 0x8d, 0x04, 0x45, 0x02, 0x00, 0x00, 0x00, 0x5d, 0xc3,
+};
+
+/* 0:  0f 95 c0                setne  al
+ * 3:  90                      nop
+ * 4:  90                      nop
+ * 5:  b8 02 00 00 00          mov    eax,0x2 ; return ADDR_TM_1D_TILED_THIN1
+ * a:  5d                      pop    ebp
+ * b:  c3                      ret
+ */
+static const uint8_t kSequoiaAmdBronzeMtlAddrLibGetBaseArrayModeReturnPatched[] = {
+    0x0f, 0x95, 0xc0, 0x90, 0x90, 0xb8, 0x02, 0x00, 0x00, 0x00, 0x5d, 0xc3,
+};
 
 static constexpr size_t kMontereyAmdBronzeMtlAddrLibGetBaseArrayModeReturnSize = sizeof(kMontereyAmdBronzeMtlAddrLibGetBaseArrayModeReturnOriginal);
 
@@ -204,7 +225,11 @@ static void patched_cs_validate_page(vnode_t vp,
             DBGLOG(MODULE_SHORT, "found function to patch at %s!", path);
             return;
         }
-
+        // covers pattern in macOS 15.0
+        if (UNLIKELY(KernelPatcher::findAndReplace(const_cast<void *>(data), PAGE_SIZE, kSequoiaAmdBronzeMtlAddrLibGetBaseArrayModeReturnOriginal, sizeof(kSequoiaAmdBronzeMtlAddrLibGetBaseArrayModeReturnOriginal), kSequoiaAmdBronzeMtlAddrLibGetBaseArrayModeReturnPatched, sizeof(kSequoiaAmdBronzeMtlAddrLibGetBaseArrayModeReturnPatched)))) {
+            DBGLOG(MODULE_SHORT, "found function to patch at %s!", path);
+            return;
+        }
     }
 }
 
@@ -315,6 +340,6 @@ PluginConfiguration ADDPR(config) {
     bootargBeta,
     arrsize(bootargBeta),
     KernelVersion::Mojave,
-    KernelVersion::Ventura,
+    KernelVersion::Sequoia,
     pluginStart
 };


### PR DESCRIPTION
@goodbest [contributed a PR for Sequoia](https://github.com/osy/Polaris22Fixup/pull/24) that hasn't yet been merged. It worked really well but broke in 15.4.1 (15.4?) because the driver changed. The original shellcode assumed the next subroutine started with a `pushq`, but it now starts with a `movq`. This PR removes the last opcode `0x55` to make it work on all known Sequoia builds.

I have verified that the new search string is still unique in the `AMDMTLBronzeDriver` driver text.

This PR also adds a short markdown doc on how to build the project for new contributors, and includes a gitignore file.